### PR TITLE
Replace clipboard dependency with VS Code API

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -2,7 +2,6 @@
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
 const path = require('path');
-var ncp = require("copy-paste");
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -74,11 +73,10 @@ function activate(context) {
 			const exp = Object.keys(env).map(key => `${key}=${env[key]}`).join(' ');
 			const line = editor.selection.active.line;
 			const command = editor.document.lineAt(line).text.split(":")[0];
-			ncp.copy(`${exp} make -C ${path.dirname(editor.document.fileName)} ${command}`, function () {
-				console.log('copy completed')
-			})
-		}
-	});
+                        await vscode.env.clipboard.writeText(`${exp} make -C ${path.dirname(editor.document.fileName)} ${command}`);
+                        console.log('copy completed');
+                }
+        });
 
 	context.subscriptions.push(copyIt, runIt);
 }

--- a/extension.js
+++ b/extension.js
@@ -10,27 +10,27 @@ const path = require('path');
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
-	let runIt = vscode.commands.registerCommand('make-runner.runIt', async function () {
-		let editor = vscode.window.activeTextEditor;
+	const runIt = vscode.commands.registerCommand('make-runner.runIt', async function () {
+		const editor = vscode.window.activeTextEditor;
 		if (editor) {
-			const filename = editor.document.fileName.split('/').pop()
-			if (filename.toLocaleLowerCase() !== 'makefile') {
-				return
+			const filename = editor.document.fileName.split('/').pop();
+			if (filename.toLowerCase() !== 'makefile') {
+				return;
 			}
-			const config = vscode.workspace.getConfiguration().get('make-runner').env;;
-			const envs = Object.keys(config);
+			const envConfig = vscode.workspace.getConfiguration('make-runner').get('env', {});
+			const envs = Object.keys(envConfig);
 
 			let env = {};
 			if (envs.length !== 0) {
 				const selection = await vscode.window.showQuickPick(envs);
 				if (!selection) {
-					return
+					return;
 				}
-				env = config[selection];
+				env = envConfig[selection];
 			}
 
 			if (typeof env !== 'object') {
-				vscode.window.showErrorMessage('Make Runner config set properly.');
+				vscode.window.showErrorMessage('Make Runner config not set properly.');
 				return;
 			}
 
@@ -42,41 +42,41 @@ function activate(context) {
 				terminal = await vscode.window.createTerminal();
 			}
 			terminal.show();
-			terminal.sendText(`${exp} make -C ${path.dirname(editor.document.fileName)} ${command}`)
+			terminal.sendText(`${exp} make -C ${path.dirname(editor.document.fileName)} ${command}`);
 		}
 	});
 
-	let copyIt = vscode.commands.registerCommand('make-runner.copyIt', async function () {
-		let editor = vscode.window.activeTextEditor;
+	const copyIt = vscode.commands.registerCommand('make-runner.copyIt', async function () {
+		const editor = vscode.window.activeTextEditor;
 		if (editor) {
-			const filename = editor.document.fileName.split('/').pop()
-			if (filename.toLocaleLowerCase() !== 'makefile') {
-				return
+			const filename = editor.document.fileName.split('/').pop();
+			if (filename.toLowerCase() !== 'makefile') {
+				return;
 			}
-			const config = vscode.workspace.getConfiguration().get('make-runner').env;
-			const envs = Object.keys(config);
+			const envConfig = vscode.workspace.getConfiguration('make-runner').get('env', {});
+			const envs = Object.keys(envConfig);
 
 			let env = {};
 			if (envs.length !== 0) {
 				const selection = await vscode.window.showQuickPick(envs);
 				if (!selection) {
-					return
+					return;
 				}
-				env = config[selection];
+				env = envConfig[selection];
 			}
 
 			if (typeof env !== 'object') {
-				vscode.window.showErrorMessage('Make Runner config set properly.');
+				vscode.window.showErrorMessage('Make Runner config not set properly.');
 				return;
 			}
 
 			const exp = Object.keys(env).map(key => `${key}=${env[key]}`).join(' ');
 			const line = editor.selection.active.line;
 			const command = editor.document.lineAt(line).text.split(":")[0];
-                        await vscode.env.clipboard.writeText(`${exp} make -C ${path.dirname(editor.document.fileName)} ${command}`);
-                        console.log('copy completed');
-                }
-        });
+			await vscode.env.clipboard.writeText(`${exp} make -C ${path.dirname(editor.document.fileName)} ${command}`);
+			console.log('copy completed');
+		}
+	});
 
 	context.subscriptions.push(copyIt, runIt);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,431 +1,537 @@
 {
 	"name": "make-runner",
-	"version": "0.0.1",
-	"lockfileVersion": 1,
+	"version": "1.0.2",
+	"lockfileVersion": 3,
 	"requires": true,
-	"dependencies": {
-		"@babel/code-frame": {
+	"packages": {
+		"": {
+			"name": "make-runner",
+			"version": "1.0.2",
+			"devDependencies": {
+				"@types/glob": "^7.1.3",
+				"@types/mocha": "^8.0.0",
+				"@types/node": "^14.0.27",
+				"@types/vscode": "^1.48.0",
+				"eslint": "^7.6.0",
+				"glob": "^7.1.6",
+				"mocha": "^8.0.1",
+				"typescript": "^3.8.3",
+				"vscode-test": "^1.4.0"
+			},
+			"engines": {
+				"vscode": "^1.48.0"
+			}
+		},
+		"node_modules/@babel/code-frame": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
 			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@babel/highlight": "^7.10.4"
 			}
 		},
-		"@babel/helper-validator-identifier": {
+		"node_modules/@babel/helper-validator-identifier": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
 			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
 			"dev": true
 		},
-		"@babel/highlight": {
+		"node_modules/@babel/highlight": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
 			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.10.4",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
 			}
 		},
-		"@types/color-name": {
+		"node_modules/@babel/highlight/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
 			"dev": true
 		},
-		"@types/glob": {
+		"node_modules/@types/glob": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/minimatch": "*",
 				"@types/node": "*"
 			}
 		},
-		"@types/minimatch": {
+		"node_modules/@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
 			"dev": true
 		},
-		"@types/mocha": {
+		"node_modules/@types/mocha": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.0.tgz",
 			"integrity": "sha512-jWeYcTo3sCH/rMgsdYXDTO85GNRyTCII5dayMIu/ZO4zbEot1E3iNGaOwpLReLUHjeNQFkgeNNVYlY4dX6azQQ==",
 			"dev": true
 		},
-		"@types/node": {
+		"node_modules/@types/node": {
 			"version": "14.0.27",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
 			"integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
 			"dev": true
 		},
-		"@types/vscode": {
+		"node_modules/@types/vscode": {
 			"version": "1.48.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.48.0.tgz",
 			"integrity": "sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==",
 			"dev": true
 		},
-		"acorn": {
+		"node_modules/acorn": {
 			"version": "7.4.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
 			"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
-		"acorn-jsx": {
+		"node_modules/acorn-jsx": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
 			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
-			"dev": true
+			"dev": true,
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0"
+			}
 		},
-		"agent-base": {
+		"node_modules/agent-base": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
 			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"es6-promisify": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
 			}
 		},
-		"ajv": {
+		"node_modules/ajv": {
 			"version": "6.12.4",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
 			"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"ansi-colors": {
+		"node_modules/ansi-colors": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
 			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"ansi-regex": {
+		"node_modules/ansi-regex": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
 			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"ansi-styles": {
+		"node_modules/ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
-		"anymatch": {
+		"node_modules/anymatch": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"argparse": {
+		"node_modules/argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
 		},
-		"array.prototype.map": {
+		"node_modules/array.prototype.map": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
 			"integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.1",
 				"es-array-method-boxes-properly": "^1.0.0",
 				"is-string": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"astral-regex": {
+		"node_modules/astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"balanced-match": {
+		"node_modules/balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
-		"binary-extensions": {
+		"node_modules/binary-extensions": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
 			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"brace-expansion": {
+		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
-		"braces": {
+		"node_modules/braces": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"fill-range": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"browser-stdout": {
+		"node_modules/browser-stdout": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
-		"callsites": {
+		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"camelcase": {
+		"node_modules/camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"chalk": {
+		"node_modules/chalk": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
 			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
 			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"chokidar": {
+		"node_modules/chalk/node_modules/ansi-styles": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+			"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+			"dev": true,
+			"dependencies": {
+				"@types/color-name": "^1.1.1",
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/chalk/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/chalk/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/chalk/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/chalk/node_modules/supports-color": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+			"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/chokidar": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
 			"integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
-				"fsevents": "~2.1.2",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
 				"readdirp": "~3.3.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.1.2"
 			}
 		},
-		"cliui": {
+		"node_modules/cliui": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
 			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"string-width": "^3.1.0",
 				"strip-ansi": "^5.2.0",
 				"wrap-ansi": "^5.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
 			}
 		},
-		"color-convert": {
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"color-name": "1.1.3"
 			}
 		},
-		"color-name": {
+		"node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
-		"concat-map": {
+		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"copy-paste": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/copy-paste/-/copy-paste-1.3.0.tgz",
-			"integrity": "sha1-p+bEocKP3t8rCB5yuX3y75X0ce0=",
-			"requires": {
-				"iconv-lite": "^0.4.8",
-				"sync-exec": "~0.6.x"
-			}
-		},
-		"cross-spawn": {
+		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"debug": {
+		"node_modules/debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ms": "^2.1.1"
 			}
 		},
-		"decamelize": {
+		"node_modules/decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"deep-is": {
+		"node_modules/deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
 		},
-		"define-properties": {
+		"node_modules/define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"object-keys": "^1.0.12"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
-		"diff": {
+		"node_modules/diff": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
-		"doctrine": {
+		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
-		"emoji-regex": {
+		"node_modules/emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
 			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
 		},
-		"enquirer": {
+		"node_modules/enquirer": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
 			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ansi-colors": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.6"
 			}
 		},
-		"es-abstract": {
+		"node_modules/es-abstract": {
 			"version": "1.17.4",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
 			"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -437,20 +543,26 @@
 				"object.assign": "^4.1.0",
 				"string.prototype.trimleft": "^2.1.1",
 				"string.prototype.trimright": "^2.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"es-array-method-boxes-properly": {
+		"node_modules/es-array-method-boxes-properly": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
 			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
 			"dev": true
 		},
-		"es-get-iterator": {
+		"node_modules/es-get-iterator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
 			"integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"es-abstract": "^1.17.4",
 				"has-symbols": "^1.0.1",
 				"is-arguments": "^1.0.4",
@@ -458,46 +570,59 @@
 				"is-set": "^2.0.1",
 				"is-string": "^1.0.5",
 				"isarray": "^2.0.5"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"es-to-primitive": {
+		"node_modules/es-to-primitive": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
 			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"es6-promise": {
+		"node_modules/es6-promise": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
 			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
 			"dev": true
 		},
-		"es6-promisify": {
+		"node_modules/es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"es6-promise": "^4.0.3"
 			}
 		},
-		"escape-string-regexp": {
+		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
 		},
-		"eslint": {
+		"node_modules/eslint": {
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.7.0.tgz",
 			"integrity": "sha512-1KUxLzos0ZVsyL81PnRN335nDtQ8/vZUD6uMtWbF+5zDtjKcsklIi78XoE0MVL93QvWTu+E5y44VyyCsOMBrIg==",
+			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
@@ -534,585 +659,776 @@
 				"table": "^5.2.3",
 				"text-table": "^0.2.0",
 				"v8-compile-cache": "^2.0.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"eslint-scope": {
+		"node_modules/eslint-scope": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
 			"integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
-		"eslint-utils": {
+		"node_modules/eslint-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
 			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"eslint-visitor-keys": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
-		"eslint-visitor-keys": {
+		"node_modules/eslint-visitor-keys": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
 			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"espree": {
+		"node_modules/espree": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-7.2.0.tgz",
 			"integrity": "sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"acorn": "^7.3.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.3.0"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"esprima": {
+		"node_modules/esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"esquery": {
+		"node_modules/esquery": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
 			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
-		"esrecurse": {
+		"node_modules/esquery/node_modules/estraverse": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+			"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esrecurse": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"estraverse": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
-		"estraverse": {
+		"node_modules/estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
 		},
-		"esutils": {
+		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"fast-deep-equal": {
+		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
-		"fast-json-stable-stringify": {
+		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
-		"fast-levenshtein": {
+		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
-		"file-entry-cache": {
+		"node_modules/file-entry-cache": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
 			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"flat-cache": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
-		"fill-range": {
+		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"find-up": {
+		"node_modules/find-up": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"flat": {
+		"node_modules/flat": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
 			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+			"deprecated": "Fixed a prototype pollution security issue in 4.1.0, please upgrade to ^4.1.1 or ^5.0.1.",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-buffer": "~2.0.3"
+			},
+			"bin": {
+				"flat": "cli.js"
 			}
 		},
-		"flat-cache": {
+		"node_modules/flat-cache": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
 			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"flatted": "^2.0.0",
 				"rimraf": "2.6.3",
 				"write": "1.0.3"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
-		"flatted": {
+		"node_modules/flatted": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
 			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
 			"dev": true
 		},
-		"fs.realpath": {
+		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
-		"fsevents": {
+		"node_modules/fsevents": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
 			"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
 			"dev": true,
-			"optional": true
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
-		"function-bind": {
+		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
-		"functional-red-black-tree": {
+		"node_modules/functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
-		"get-caller-file": {
+		"node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
 		},
-		"glob": {
+		"node_modules/glob": {
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
 				"minimatch": "^3.0.4",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"glob-parent": {
+		"node_modules/glob-parent": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
 			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"globals": {
+		"node_modules/globals": {
 			"version": "12.4.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
 			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"type-fest": "^0.8.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"growl": {
+		"node_modules/growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4.x"
+			}
 		},
-		"has": {
+		"node_modules/has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
 			}
 		},
-		"has-flag": {
+		"node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"has-symbols": {
+		"node_modules/has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"he": {
+		"node_modules/he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"he": "bin/he"
+			}
 		},
-		"http-proxy-agent": {
+		"node_modules/http-proxy-agent": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
 			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"agent-base": "4",
 				"debug": "3.1.0"
 			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
+			"engines": {
+				"node": ">= 4.5.0"
 			}
 		},
-		"https-proxy-agent": {
+		"node_modules/http-proxy-agent/node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/http-proxy-agent/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"node_modules/https-proxy-agent": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
 			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
 			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/https-proxy-agent/node_modules/debug": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"dev": true,
 			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
+				"ms": "^2.1.1"
 			}
 		},
-		"iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			}
-		},
-		"ignore": {
+		"node_modules/ignore": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
 		},
-		"import-fresh": {
+		"node_modules/import-fresh": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
 			"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
-		"imurmurhash": {
+		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.19"
+			}
 		},
-		"inflight": {
+		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
 			}
 		},
-		"inherits": {
+		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
-		"is-arguments": {
+		"node_modules/is-arguments": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
 			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
-		"is-binary-path": {
+		"node_modules/is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
 			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"binary-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"is-buffer": {
+		"node_modules/is-buffer": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
 			"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"is-callable": {
+		"node_modules/is-callable": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
 			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"is-date-object": {
+		"node_modules/is-date-object": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
 			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"is-extglob": {
+		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"is-fullwidth-code-point": {
+		"node_modules/is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"is-glob": {
+		"node_modules/is-glob": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
 			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
-		"is-map": {
+		"node_modules/is-map": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
 			"integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
-			"dev": true
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"is-number": {
+		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
+			}
 		},
-		"is-plain-obj": {
+		"node_modules/is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"is-regex": {
+		"node_modules/is-regex": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
 			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-set": {
+		"node_modules/is-set": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
 			"integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
-			"dev": true
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"is-string": {
+		"node_modules/is-string": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
 			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"is-symbol": {
+		"node_modules/is-symbol": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
 			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has-symbols": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"isarray": {
+		"node_modules/isarray": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
 			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
 			"dev": true
 		},
-		"isexe": {
+		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
 		},
-		"iterate-iterator": {
+		"node_modules/iterate-iterator": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
 			"integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==",
 			"dev": true
 		},
-		"iterate-value": {
+		"node_modules/iterate-value": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
 			"integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"es-get-iterator": "^1.0.2",
 				"iterate-iterator": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"js-tokens": {
+		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true
 		},
-		"js-yaml": {
+		"node_modules/js-yaml": {
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"json-schema-traverse": {
+		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
-		"json-stable-stringify-without-jsonify": {
+		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
 		},
-		"levn": {
+		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"locate-path": {
+		"node_modules/locate-path": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"lodash": {
+		"node_modules/lodash": {
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 			"dev": true
 		},
-		"log-symbols": {
+		"node_modules/log-symbols": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
 			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"chalk": "^2.4.2"
 			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"minimatch": {
+		"node_modules/log-symbols/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
-		"minimist": {
+		"node_modules/minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
 		},
-		"mkdirp": {
+		"node_modules/mkdirp": {
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"minimist": "^1.2.5"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
 			}
 		},
-		"mocha": {
+		"node_modules/mocha": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.1.tgz",
 			"integrity": "sha512-p7FuGlYH8t7gaiodlFreseLxEmxTgvyG9RgPHODFPySNhwUehu8NIb0vdSt3WFckSneswZ0Un5typYcWElk7HQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
 				"chokidar": "3.3.1",
@@ -1139,577 +1455,773 @@
 				"yargs-parser": "13.1.2",
 				"yargs-unparser": "1.6.1"
 			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"strip-json-comments": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+			"bin": {
+				"_mocha": "bin/_mocha",
+				"mocha": "bin/mocha"
+			},
+			"engines": {
+				"node": ">= 10.12.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mochajs"
 			}
 		},
-		"ms": {
+		"node_modules/mocha/node_modules/debug": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/mocha/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/mocha/node_modules/strip-json-comments": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+			"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/mocha/node_modules/supports-color": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+			"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
-		"natural-compare": {
+		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"normalize-path": {
+		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"object-inspect": {
+		"node_modules/object-inspect": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
 			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-			"dev": true
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"object-keys": {
+		"node_modules/object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
-		"object.assign": {
+		"node_modules/object.assign": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
 				"has-symbols": "^1.0.0",
 				"object-keys": "^1.0.11"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
-		"once": {
+		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"wrappy": "1"
 			}
 		},
-		"optionator": {
+		"node_modules/optionator": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
 			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
 				"type-check": "^0.4.0",
 				"word-wrap": "^1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"p-limit": {
+		"node_modules/p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"p-locate": {
+		"node_modules/p-locate": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"p-try": {
+		"node_modules/p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"parent-module": {
+		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
-		"path-exists": {
+		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"path-is-absolute": {
+		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"path-key": {
+		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"picomatch": {
+		"node_modules/picomatch": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
 		},
-		"prelude-ls": {
+		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
 		},
-		"progress": {
+		"node_modules/progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
-		"promise.allsettled": {
+		"node_modules/promise.allsettled": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
 			"integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"array.prototype.map": "^1.0.1",
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.1",
 				"function-bind": "^1.1.1",
 				"iterate-value": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"punycode": {
+		"node_modules/punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"randombytes": {
+		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
 		},
-		"readdirp": {
+		"node_modules/readdirp": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
 			"integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"picomatch": "^2.0.7"
+			},
+			"engines": {
+				"node": ">=8.10.0"
 			}
 		},
-		"regexpp": {
+		"node_modules/regexpp": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
 			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			}
 		},
-		"require-directory": {
+		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"require-main-filename": {
+		"node_modules/require-main-filename": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
-		"resolve-from": {
+		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"rimraf": {
+		"node_modules/rimraf": {
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
 			}
 		},
-		"safe-buffer": {
+		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"semver": {
+		"node_modules/semver": {
 			"version": "7.3.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
 			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
-		"serialize-javascript": {
+		"node_modules/serialize-javascript": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
 			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
 		},
-		"set-blocking": {
+		"node_modules/set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
 		},
-		"shebang-command": {
+		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"shebang-regex": {
+		"node_modules/shebang-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"slice-ansi": {
+		"node_modules/slice-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
 			"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ansi-styles": "^3.2.0",
 				"astral-regex": "^1.0.0",
 				"is-fullwidth-code-point": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
-		"sprintf-js": {
+		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
-		"string-width": {
+		"node_modules/string-width": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"emoji-regex": "^7.0.1",
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^5.1.0"
 			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
+			"engines": {
+				"node": ">=6"
 			}
 		},
-		"string.prototype.trimleft": {
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/string.prototype.trimleft": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
 			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3",
 				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"string.prototype.trimright": {
+		"node_modules/string.prototype.trimright": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
 			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3",
 				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"strip-ansi": {
+		"node_modules/strip-ansi": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
 			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ansi-regex": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"strip-json-comments": {
+		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
-		"supports-color": {
+		"node_modules/supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
-		"sync-exec": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.6.2.tgz",
-			"integrity": "sha1-cX0izFPwzh3vVZQ2LzqJouu5EQU=",
-			"optional": true
-		},
-		"table": {
+		"node_modules/table": {
 			"version": "5.4.6",
 			"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
 			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ajv": "^6.10.2",
 				"lodash": "^4.17.14",
 				"slice-ansi": "^2.1.0",
 				"string-width": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
-		"text-table": {
+		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
 		},
-		"to-regex-range": {
+		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
 			}
 		},
-		"type-check": {
+		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"type-fest": {
+		"node_modules/type-fest": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
 			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"typescript": {
+		"node_modules/typescript": {
 			"version": "3.9.7",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
 			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
 		},
-		"uri-js": {
+		"node_modules/uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"punycode": "^2.1.0"
 			}
 		},
-		"v8-compile-cache": {
+		"node_modules/v8-compile-cache": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
 			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
 			"dev": true
 		},
-		"vscode-test": {
+		"node_modules/vscode-test": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.4.0.tgz",
 			"integrity": "sha512-Jt7HNGvSE0+++Tvtq5wc4hiXLIr2OjDShz/gbAfM/mahQpy4rKBnmOK33D+MR67ATWviQhl+vpmU3p/qwSH/Pg==",
+			"deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"http-proxy-agent": "^2.1.0",
 				"https-proxy-agent": "^2.2.4",
 				"rimraf": "^2.6.3"
+			},
+			"engines": {
+				"node": ">=8.9.3"
 			}
 		},
-		"which": {
+		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"which-module": {
+		"node_modules/which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
 		},
-		"wide-align": {
+		"node_modules/wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"dev": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
+				"string-width": "^1.0.2 || 2"
 			}
 		},
-		"word-wrap": {
+		"node_modules/wide-align/node_modules/ansi-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/wide-align/node_modules/string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"dependencies": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/wide-align/node_modules/strip-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"workerpool": {
+		"node_modules/workerpool": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.0.tgz",
 			"integrity": "sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==",
 			"dev": true
 		},
-		"wrap-ansi": {
+		"node_modules/wrap-ansi": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
 			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ansi-styles": "^3.2.0",
 				"string-width": "^3.0.0",
 				"strip-ansi": "^5.0.0"
 			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
+			"engines": {
+				"node": ">=6"
 			}
 		},
-		"wrappy": {
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
 		},
-		"write": {
+		"node_modules/write": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
 			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"mkdirp": "^0.5.1"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
-		"y18n": {
+		"node_modules/y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 			"dev": true
 		},
-		"yargs": {
+		"node_modules/yargs": {
 			"version": "13.3.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
 			"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"cliui": "^5.0.0",
 				"find-up": "^3.0.0",
 				"get-caller-file": "^2.0.1",
@@ -1720,130 +2232,153 @@
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
 				"yargs-parser": "^13.1.2"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				}
 			}
 		},
-		"yargs-parser": {
+		"node_modules/yargs-parser": {
 			"version": "13.1.2",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
 			"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
 			}
 		},
-		"yargs-unparser": {
+		"node_modules/yargs-unparser": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
 			"integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"camelcase": "^5.3.1",
 				"decamelize": "^1.2.0",
 				"flat": "^4.1.0",
 				"is-plain-obj": "^1.1.0",
 				"yargs": "^14.2.3"
 			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs-unparser/node_modules/find-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
 			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				},
-				"yargs": {
-					"version": "14.2.3",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-					"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-					"dev": true,
-					"requires": {
-						"cliui": "^5.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^15.0.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "15.0.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-					"integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
+				"locate-path": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs-unparser/node_modules/locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs-unparser/node_modules/p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs-unparser/node_modules/path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/yargs-unparser/node_modules/yargs": {
+			"version": "14.2.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+			"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^5.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^3.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^15.0.1"
+			}
+		},
+		"node_modules/yargs-unparser/node_modules/yargs-parser": {
+			"version": "15.0.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+			"integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			}
+		},
+		"node_modules/yargs/node_modules/find-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs/node_modules/locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs/node_modules/p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs/node_modules/path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Makefile Runner",
 	"description": "Run Makefile easily",
 	"publisher": "rajivshah01234",
-	"icon" : "images/makerunnerIcon.png",
+	"icon": "images/makerunnerIcon.png",
 	"version": "1.0.2",
 	"engines": {
 		"vscode": "^1.48.0"
@@ -59,17 +59,14 @@
 		"test": "node ./test/runTest.js"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.48.0",
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^8.0.0",
 		"@types/node": "^14.0.27",
+		"@types/vscode": "^1.48.0",
 		"eslint": "^7.6.0",
 		"glob": "^7.1.6",
 		"mocha": "^8.0.1",
 		"typescript": "^3.8.3",
 		"vscode-test": "^1.4.0"
-	},
-	"dependencies": {
-		"copy-paste": "^1.3.0"
 	}
 }


### PR DESCRIPTION
## Summary
- remove the deprecated `copy-paste` runtime dependency
- switch the copy command to use the built-in VS Code clipboard API
- regenerate the lockfile to reflect the dependency removal

## Testing
- npm test *(fails: `ERR_SOCKET_CLOSED` while downloading VS Code test resources)*

------
https://chatgpt.com/codex/tasks/task_b_68e37ae23dec8329919fa9a8d5635345